### PR TITLE
Autocomplete: Allow loading from other locations

### DIFF
--- a/adminer-plugins/autocomplete.php
+++ b/adminer-plugins/autocomplete.php
@@ -12,7 +12,12 @@ class AdminerAutocomplete
 		'LIMIT', 'LEFT JOIN', 'NULL', 'ORDER BY', 'ON DUPLICATE KEY UPDATE', 'SELECT', 'UPDATE', 'WHERE',
 	];
 
-
+	public function __construct(
+		private string $root = 'static/ace',
+		private string $minified = '',
+	) {
+	}
+	
 	public function syntaxHighlighting($tableStatuses)
 	{
 		$suggests = [];
@@ -30,8 +35,8 @@ class AdminerAutocomplete
 	border: 1px solid black;
 }
 </style>
-<script<?= Adminer\nonce() ?> src="static/ace/ace.js"></script>
-<script<?= Adminer\nonce() ?> src="static/ace/ext-language_tools.js"></script>
+<script<?= Adminer\nonce() ?> src="<?= $this->root ?>/ace<?= $this->minified ?>.js"></script>
+<script<?= Adminer\nonce() ?> src="<?= $this->root ?>/ext-language_tools<?= $this->minified ?>.js"></script>
 <script<?= Adminer\nonce() ?>>
 document.addEventListener('DOMContentLoaded', () => {
 
@@ -45,7 +50,7 @@ document.addEventListener('DOMContentLoaded', () => {
 	let form = textarea.form;
 	let editor;
 
-	ace.config.set('basePath', 'static/ace');
+	ace.config.set('basePath', '<?= $this->root ?>');
 	editor = ace.edit(textarea);
 	editor.setTheme('ace/theme/tomorrow');
 	editor.session.setMode('ace/mode/sql');


### PR DESCRIPTION
E.g. from jsDelivr: `new AdminerAutocomplete('https://cdn.jsdelivr.net/npm/ace-builds@1.39.1/src-min', '.min')`