### PR TITLE
Lowercase the host_info in remote address check

### DIFF
--- a/adminer-plugins/remoteColor.php
+++ b/adminer-plugins/remoteColor.php
@@ -13,7 +13,7 @@ class AdminerRemoteColor
 		$connection = Adminer\connection();
 		if (
 			(isset($_SERVER['HTTP_X_FORWARDED_FOR']) || !isset($_SERVER['REMOTE_ADDR']) || !in_array($_SERVER['REMOTE_ADDR'], $localhosts, true))
-			|| ($connection instanceof mysqli && !in_array(explode(' ', $connection->host_info)[0], $localhosts, true))
+			|| ($connection instanceof mysqli && !in_array(strtolower(explode(' ', $connection->host_info)[0]), $localhosts, true))
 		) {
 			echo '<script' . Adminer\nonce() . '>document.documentElement.className+=" remote";</script>';
 		}


### PR DESCRIPTION
In my case host_info returns "Localhost via UNIX socket" meaning "Localhost" won't be found in the $localhosts array.

"Localhost" is also mentioned in [the `host_info` manual page](https://www.php.net/manual/en/mysqli.get-host-info.php) in the example output.